### PR TITLE
fix bug where nil or @{} params would cause invalid signature

### DIFF
--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -180,9 +180,6 @@ static NSString* timestamp() {
 
 // unencodedParameters are encoded and assigned to self->params, returns encoded queryString
 - (id)setParameters:(NSDictionary *)unencodedParameters {
-    if (!unencodedParameters.count)
-        return nil;
-
     NSMutableString *queryString = [NSMutableString string];
     NSMutableDictionary *encodedParameters = [NSMutableDictionary new];
     for (NSString *key in unencodedParameters.allKeys)


### PR DESCRIPTION
When setting params to @{}, the params instance variable was not being set. In turn, this caused an invalid signature to be created in the signature_base method.
