### PR TITLE
Fix double encoding in signature

### DIFF
--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -124,7 +124,8 @@ static NSString* timestamp() {
     NSArray *keys = [[sigParams allKeys] sortedArrayUsingSelector:@selector(compare:)];
     for (NSString *key in keys)
     {
-        [p3 appendString:TDPCEN(key)];
+        //[p3 appendString:TDPCEN(key)];
+        [p3 appendString:key];
         [p3 appendString:@"="];
         [p3 appendString:[sigParams[key] description]];
         [p3 appendString:@"&"];


### PR DESCRIPTION
This fixes an issue where parameter keys are double encoded when
generating a signature.  This results in a incorrect signature being
created.

This shows up when performing a POST with array parameters.

eg. @{@“invites[1]”= @“jon.doe”}
