### PR TITLE
Support for encoding parameters in query string for POST requests

### DIFF
--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
 };
 typedef NS_ENUM(NSInteger, TDOAuthContentType) {
     TDOAuthContentTypeUrlEncodedForm,
+    TDOAuthContentTypeUrlEncodedParameter,
     TDOAuthContentTypeJsonObject,
 };
 
@@ -100,8 +101,9 @@ typedef NS_ENUM(NSInteger, TDOAuthContentType) {
  @p requestMethod may be any string value. There is no validation, so remember that all
  currently-defined HTTP methods are uppercase and the RFC specifies that the method
  is case-sensitive.
- @p dataEncoding allows for the transmission of data as either URL-encoded form data or
- JSON by passing the value TDOAuthContentTypeUrlEncodedForm or TDOAuthContentTypeJsonObject.
+ @p dataEncoding allows for the transmission of data as either URL-encoded form data,
+ URL-encoded parameter(s) or JSON by passing the value TDOAuthContentTypeUrlEncodedForm,
+ TDOAuthContentTypeUrlEncodedParameter or TDOAuthContentTypeJsonObject.
  This parameter is ignored for the requestMethod "GET".
  @p headerValues accepts a hash of key-value pairs (both must be strings) that specify
  HTTP header values to be included in the resulting URL Request. For example, the argument

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
 };
 typedef NS_ENUM(NSInteger, TDOAuthContentType) {
     TDOAuthContentTypeUrlEncodedForm,
-    TDOAuthContentTypeUrlEncodedParameter,
+    TDOAuthContentTypeUrlEncodedQuery,
     TDOAuthContentTypeJsonObject,
 };
 
@@ -102,8 +102,8 @@ typedef NS_ENUM(NSInteger, TDOAuthContentType) {
  currently-defined HTTP methods are uppercase and the RFC specifies that the method
  is case-sensitive.
  @p dataEncoding allows for the transmission of data as either URL-encoded form data,
- URL-encoded parameter(s) or JSON by passing the value TDOAuthContentTypeUrlEncodedForm,
- TDOAuthContentTypeUrlEncodedParameter or TDOAuthContentTypeJsonObject.
+ query string or JSON by passing the value TDOAuthContentTypeUrlEncodedForm,
+ TDOAuthContentTypeUrlEncodedQuery or TDOAuthContentTypeJsonObject.
  This parameter is ignored for the requestMethod "GET".
  @p headerValues accepts a hash of key-value pairs (both must be strings) that specify
  HTTP header values to be included in the resulting URL Request. For example, the argument

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -267,7 +267,7 @@ static NSString* timestamp() {
     oauth->hostAndPathWithoutQuery = [host.lowercaseString stringByAppendingString:encodedPathWithoutQuery];
 
     NSMutableURLRequest *rq;
-    if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"] || [method isEqualToString:@"HEAD"])
+    if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"] || [method isEqualToString:@"HEAD"] || ([method isEqualToString:@"POST"] && dataEncoding == TDOAuthContentTypeUrlEncodedParameter))
     {
         id path = [oauth setParameters:unencodedParameters];
         if (path && unencodedParameters) {

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -267,7 +267,7 @@ static NSString* timestamp() {
     oauth->hostAndPathWithoutQuery = [host.lowercaseString stringByAppendingString:encodedPathWithoutQuery];
 
     NSMutableURLRequest *rq;
-    if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"] || [method isEqualToString:@"HEAD"] || ([method isEqualToString:@"POST"] && dataEncoding == TDOAuthContentTypeUrlEncodedParameter))
+    if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"] || [method isEqualToString:@"HEAD"] || ([method isEqualToString:@"POST"] && dataEncoding == TDOAuthContentTypeUrlEncodedQuery))
     {
         id path = [oauth setParameters:unencodedParameters];
         if (path && unencodedParameters) {

--- a/Tests/MainTests.m
+++ b/Tests/MainTests.m
@@ -171,7 +171,7 @@
 
 - (void)testPostUrlParameters
 {
-    NSURLRequest *postRequest = [TDOAuthTest makePostRequestWithDataEncoding:TDOAuthContentTypeUrlEncodedParameter];
+    NSURLRequest *postRequest = [TDOAuthTest makePostRequestWithDataEncoding:TDOAuthContentTypeUrlEncodedQuery];
     
     NSString *url = [[postRequest URL] absoluteString];
     XCTAssert([url isEqualToString:@"http://api.example.com/service?foo=bar&baz=bonk"],

--- a/Tests/MainTests.m
+++ b/Tests/MainTests.m
@@ -40,6 +40,21 @@
                           accessToken:@"ijkl"
                           tokenSecret:@"mnop"];
 }
++ (NSURLRequest *)makePostRequestWithDataEncoding:(TDOAuthContentType)dataEncoding
+{
+    return [TDOAuth URLRequestForPath:@"/service"
+                           parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                 host:@"api.example.com"
+                          consumerKey:@"abcd"
+                       consumerSecret:@"efgh"
+                          accessToken:@"ijkl"
+                          tokenSecret:@"mnop"
+                               scheme:@"http"
+                        requestMethod:@"POST"
+                         dataEncoding:dataEncoding
+                         headerValues:nil
+                      signatureMethod:TDOAuthSignatureMethodHmacSha1];
+}
 + (NSURLRequest *)makeGenericRequestWithHTTPMethod:(NSString *)method
 {
     return [TDOAuth URLRequestForPath:@"/service"
@@ -153,6 +168,24 @@
                  @"Accept is not expected value)");
 
 }
+
+- (void)testPostUrlParameters
+{
+    NSURLRequest *postRequest = [TDOAuthTest makePostRequestWithDataEncoding:TDOAuthContentTypeUrlEncodedParameter];
+    
+    NSString *url = [[postRequest URL] absoluteString];
+    XCTAssert([url isEqualToString:@"http://api.example.com/service?foo=bar&baz=bonk"],
+              "url does not match expected value");
+    
+    NSString *contentType = [postRequest valueForHTTPHeaderField: @"Content-Type"];
+    XCTAssertNil(contentType,
+                 @"Content-Type was present when not expected)");
+    
+    NSString *contentLength = [postRequest valueForHTTPHeaderField: @"Content-Length"];
+    XCTAssertNil(contentLength,
+                 @"Content-Length was set when not expected)");
+}
+
 - (void)testPostHeaderAuthField
 {
     NSURLRequest *postRequest = [TDOAuthTest makePostRequest];


### PR DESCRIPTION
#### Description
This PR adds support for encoding parameters in query string for POST requests. Currently, TDOAuth only allows parameters in the body of request for POST requests.

#### Changes
- Added "TDOAuthContentTypeUrlEncodedQuery" as a "TDOAuthContentType". 
- Updated code to allow transmission of data as URL encoded parameters in case of POST requests
- Added test to validate URLRequest generated for POST with TDOAuthContentTypeUrlEncodedQuery data encoding.
