### PR TITLE
Allow PUT request to use TDOAuthContentTypeUrlEncodedQuery data encoding

### DIFF
--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -267,7 +267,7 @@ static NSString* timestamp() {
     oauth->hostAndPathWithoutQuery = [host.lowercaseString stringByAppendingString:encodedPathWithoutQuery];
 
     NSMutableURLRequest *rq;
-    if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"] || [method isEqualToString:@"HEAD"] || ([method isEqualToString:@"POST"] && dataEncoding == TDOAuthContentTypeUrlEncodedQuery))
+    if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"] || [method isEqualToString:@"HEAD"] || (([method isEqualToString:@"POST"] || [method isEqualToString:@"PUT"]) && dataEncoding == TDOAuthContentTypeUrlEncodedQuery))
     {
         id path = [oauth setParameters:unencodedParameters];
         if (path && unencodedParameters) {


### PR DESCRIPTION
Currently, we only support TDOAuthContentTypeUrlEncodedQuery for a POST request. Updated the code to allow a PUT request to use TDOAuthContentTypeUrlEncodedQuery data encoding.