### PR TITLE
Fix for pod not building when using static libraries

### DIFF
--- a/Source/compat/TDOAuth.m
+++ b/Source/compat/TDOAuth.m
@@ -28,7 +28,11 @@
 */
 
 #import "TDOAuth.h"
+#if __has_include("TDOAuth-Swift.h")
+#import "TDOAuth-Swift.h"
+#else
 #import <TDOAuth/TDOAuth-Swift.h>
+#endif
 #import <OMGHTTPURLRQ/OMGUserAgent.h>
 
 #define TDPCEN(s) \


### PR DESCRIPTION
This fixes the pod not being able to build for static libraries.
The problem can be seen when linting the pod.
```
pod spec lint --use-libraries --use-modular-headers
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
