### PR TITLE
Respect trailing slashes in URLs

### DIFF
--- a/Example/Tests/OAuth1Spec.swift
+++ b/Example/Tests/OAuth1Spec.swift
@@ -218,7 +218,7 @@ class RFC5839Spec: XCTestCase {
         let signedRequest2 = oauth1.sign(request: uppercaseRequest)
         let gotAuthHeader = signedRequest2?.value(forHTTPHeaderField: "Authorization")
 
-        XCTAssertNotNil(signedRequest)
+        XCTAssertNotNil(signedRequest2)
         XCTAssertEqual(expectAuthHeader, gotAuthHeader)
     }
 
@@ -237,7 +237,23 @@ class RFC5839Spec: XCTestCase {
         let signedRequest2 = oauth1.sign(request: uppercaseRequest)
         let gotAuthHeader = signedRequest2?.value(forHTTPHeaderField: "Authorization")
 
-        XCTAssertNotNil(signedRequest)
+        XCTAssertNotNil(signedRequest2)
         XCTAssertEqual(expectAuthHeader, gotAuthHeader)
+    }
+
+    func testRespectsTrailingSlashesCase() {
+        oauth1 = TestOAuth1(withConsumerKey: "dpf43f3p2l4k3l03", accessToken: nil, signer: signer)
+
+        var components = URLComponents(url: rfcRequest.url!, resolvingAgainstBaseURL: false)
+        components?.path = "/a/b/c/"
+        var request = rfcRequest
+        request.url = components?.url!
+
+        let signedRequest = oauth1.sign(request: request)
+        let gotAuthHeader = signedRequest?.value(forHTTPHeaderField: "Authorization")
+
+        XCTAssertNotNil(signedRequest)
+        let expect = "OAuth oauth_nonce=\"kllo9940pd9333jh\", oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"dpf43f3p2l4k3l03\", oauth_timestamp=\"1191242096\", oauth_version=\"1.0\", oauth_signature=\"ixhhhte3356BnKrwap0ZttXlIFg%3D\""
+        XCTAssertEqual(expect, gotAuthHeader)
     }
 }

--- a/Source/TDOAuth.swift
+++ b/Source/TDOAuth.swift
@@ -191,8 +191,14 @@ open class OAuth1<T: OAuth1Signer> {
         //
         // is represented by the base string URI:
         // "https://www.example.net:8080/".
-        let scheme = url.scheme?.lowercased() ?? "https"
-        let host = url.host?.lowercased() ?? ""
+
+        // Using URLComponents because it provides a more precise URL parser than
+        // properties of (NS)URL. For example, currently `URL.path` drops tailing slashes
+        // and does other interpretations on the path which cause it to differ from the
+        // value that would be transmitted in a URLRequest.
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return "" }
+        let scheme = components.scheme?.lowercased() ?? "https"
+        let host = components.host?.lowercased() ?? ""
         let port: String
         switch url.port {
         case .some(let p) where p == 80 && scheme == "http": // default port, elide
@@ -204,7 +210,7 @@ open class OAuth1<T: OAuth1Signer> {
         case .some(let p):
             port = ":\(p)"
         }
-        let path = url.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        let path = components.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         let baseStringUri = "\(scheme)://\(host)\(port)\(path)"
         return baseStringUri
     }


### PR DESCRIPTION
Fixed a bug found in Yahoo Finance where a request with a trailing slash had an invalid OAuth signature

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
