### PR TITLE
Use more restrictive non-escaped character set, per RFC 5849 Section 3.6

### DIFF
--- a/Source/StringUtils.swift
+++ b/Source/StringUtils.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-let urlSafeCharacters: CharacterSet = CharacterSet(charactersIn: "^!*'();:@&=+$,/?%#[]{}\"`<>\\| ").inverted
+let urlSafeCharacters: CharacterSet = CharacterSet(charactersIn: "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-._~")
 
 public extension String {
 

--- a/Source/compat/TDOAuth.m
+++ b/Source/compat/TDOAuth.m
@@ -36,7 +36,7 @@
 #import <OMGHTTPURLRQ/OMGUserAgent.h>
 
 #define TDPCEN(s) \
-      ([[s description] stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@"^!*'();:@&=+$,/?%#[]{}\"`<>\\| "] invertedSet]])
+      ([[s description] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet characterSetWithCharactersInString:@"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-._~"]])
 
 #define TDChomp(s) { \
     const NSUInteger length = [s length]; \


### PR DESCRIPTION
 Use more restrictive non-escaped character set, per OAuth Spec (RFC 5849 Section 3.6)

https://datatracker.ietf.org/doc/html/rfc5849#section-3.6

Motivation: \n should be percent encoded. Rather than keep battling this (ala https://github.com/yahoo/TDOAuth/issues/23), here's a PR that I think is literally what the OAuth spec demands for URL encoding characters that aren't a-z, A-z, 0-9, and the reserved characters:

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
