### PR TITLE
Add SwiftPM and Github actions support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,66 @@
+name: "TDOAuth CI"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  Example:
+    name: Example Project (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod install
+        run: pod install --project-directory=Example
+
+      - name: Build Project
+        uses: sersoft-gmbh/xcodebuild-action@v1.8.0
+        with:
+          workspace: Example/TDOAuth.xcworkspace
+          scheme: TDOAuth_iOS
+          destination: name=iPhone 13 Pro
+          action: test
+          
+  Pods:
+    name: Cocoapods Lint (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod lib lint dynamic-framework
+        run: pod lib lint --fail-fast
+
+      - name: Run pod lib lint static-framework
+        run: pod lib lint --fail-fast --use-libraries --use-modular-headers
+          
+  SwiftPM:
+    name: SwiftPM (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable 
+
+      - name: Build
+        run: swift build

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ Carthage/Build
 # `pod install` in .travis.yml
 #
 Pods/
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-os: osx
-osx_image: xcode11.3
-#language: swift -- this is an alias to objective-c
-language: objective-c
-podfile: Example/Podfile
-xcode_workspace: Example/TDOAuth.xcworkspace
-xcode_scheme: TDOAuth_iOS
-xcode_destination: platform=iOS Simulator,OS=12.0,name=iPhone XS

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,57 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TDOAuth",
+    platforms: [
+        .iOS(.v9),
+        .tvOS(.v11),
+        .watchOS(.v3),
+        .macOS(.v10_10)
+    ],
+    products: [
+        .library(
+            name: "TDOAuth",
+            targets: ["TDOAuth"]),
+        .library(
+            name: "TDOAuthSwift",
+            targets: ["TDOAuthSwift"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/mxcl/OMGHTTPURLRQ.git", .upToNextMajor(from: "3.3.0"))
+    ],
+    targets: [
+        .target(
+            name: "TDOAuth",
+            dependencies: [
+                "TDOAuthCompat"
+            ],
+            path: "Source/compat",
+            exclude: [
+                "Compat.swift"
+            ],
+            publicHeadersPath: "."),
+        .target(
+            name: "TDOAuthCompat",
+            dependencies: [
+                "TDOAuthSwift"
+            ],
+            path: "Source/compat",
+            exclude: [
+                "TDOAuth.h",
+                "TDOAuth.m"
+            ]),
+        .target(
+            name: "TDOAuthSwift",
+            dependencies: [
+                "OMGHTTPURLRQ"
+            ],
+            path: "Source",
+            exclude: [
+                "compat/TDOAuth.h",
+                "compat/TDOAuth.m",
+                "compat/Compat.swift"
+            ]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TDOAuth
 
-[![CI Status](https://img.shields.io/travis/Yahoo/TDOAuth.svg?style=flat)](https://travis-ci.org/Yahoo/TDOAuth)
+[![CI Status](https://github.com/yahoo/TDOAuth/workflows/TDOAuth%20CI/badge.svg?branch=master)](https://github.com/yahoo/TDOAuth/actions)
+[![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 [![Version](https://img.shields.io/cocoapods/v/TDOAuth.svg?style=flat)](https://cocoapods.org/pods/TDOAuth)
 [![License](https://img.shields.io/cocoapods/l/TDOAuth.svg?style=flat)](https://cocoapods.org/pods/TDOAuth)
 [![Platform](https://img.shields.io/cocoapods/p/TDOAuth.svg?style=flat)](https://cocoapods.org/pods/TDOAuth)
@@ -15,12 +16,18 @@ Swift 4, 4.2 or 5. The pure-Swift subspec has no dependencies.
 
 ## Installation
 
+### CocoaPods
+
 TDOAuth is available through [CocoaPods](https://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
 pod 'TDOAuth'
 ```
+
+### SwiftPM
+
+Add `.package(url: "https://github.com/yahoo/TDOAuth.git", from: "1.5.0")` to your `package.swift`
 
 ## Usage (Swift)
 

--- a/Source/TDOAuth.swift
+++ b/Source/TDOAuth.swift
@@ -1,6 +1,8 @@
 // Copyright 2021, Yahoo Inc.
 // Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/TDOAuth for terms.
 
+import Foundation
+
 /// See https://tools.ietf.org/html/rfc5849
 open class OAuth1<T: OAuth1Signer> {
 

--- a/Source/compat/Compat.swift
+++ b/Source/compat/Compat.swift
@@ -3,6 +3,14 @@
 
 import Foundation
 
+#if SWIFT_PACKAGE
+import TDOAuthSwift
+
+@objc public enum TDOAuthSignatureMethod: Int {
+    case hmacSha1, hmacSha256
+}
+#endif
+
 @objc public class TDOAuthCompat: NSObject {
 
     static var OAuth1Type: OAuth1.Type = OAuth1<HMACSigner>.self

--- a/Source/compat/TDOAuth.h
+++ b/Source/compat/TDOAuth.h
@@ -30,10 +30,15 @@
 #import <Foundation/Foundation.h>
 #import <Availability.h>
 
+#ifdef SWIFT_PACKAGE
+@import TDOAuthCompat;
+#else
 typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
     TDOAuthSignatureMethodHmacSha1,
     TDOAuthSignatureMethodHmacSha256,
 };
+#endif
+
 typedef NS_ENUM(NSInteger, TDOAuthContentType) {
     TDOAuthContentTypeUrlEncodedForm,
     TDOAuthContentTypeJsonObject,

--- a/Source/compat/TDOAuth.m
+++ b/Source/compat/TDOAuth.m
@@ -30,10 +30,14 @@
 #import "TDOAuth.h"
 #if __has_include("TDOAuth-Swift.h")
 #import "TDOAuth-Swift.h"
-#else
+#elif __has_include(<TDOAuth/TDOAuth-Swift.h>)
 #import <TDOAuth/TDOAuth-Swift.h>
 #endif
+#if __has_include(<OMGHTTPURLRQ/OMGUserAgent.h>)
 #import <OMGHTTPURLRQ/OMGUserAgent.h>
+#else
+@import OMGHTTPURLRQ;
+#endif
 
 #define TDPCEN(s) \
       ([[s description] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet characterSetWithCharactersInString:@"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-._~"]])

--- a/TDOAuth.podspec
+++ b/TDOAuth.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TDOAuth'
-  s.version          = '1.4.3'
+  s.version          = '1.5.0'
   s.summary          = 'Elegant, simple and compliant OAuth 1.x solution.'
 
   s.description      = <<-DESC

--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,1 +1,0 @@
-Example/Pods/Pods.xcodeproj


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

* Add a SwiftPM manifest file
* Bump version to 1.5.0
* Update the .gitignore file to ignore local swiftpm artifacts
* Replace travis-ci with Github actions for continuous integration as travis-ci.org has ceased. Actions will take into affect immediately as shown on my fork: https://github.com/master-nevi/TDOAuth/actions
* Update README badge
* Removed the `_Pods.xcodeproj` symlink as it doesn't appear to be used. I can add it back but I believe it's an artifact of the original [`pod lib create`](https://guides.cocoapods.org/making/using-pod-lib-create) for Carthage support which isn't referenced in the README.

NOTE: SwiftPM does not support targets with mixed languages. I had to separate the Obj-C compatibility layer into two targets since it contains both Swift and Objective-C code. I also had to resolve a dependency cycle involving `TDOAuthSignatureMethod` to make this work without any major changes. Other than the extra target, the library structure resembles that of the podspec. The change has no affect on the Cocoapods installation.