### PR TITLE
Fix dropped non-string parameters types

### DIFF
--- a/Example/Tests/Compat.m
+++ b/Example/Tests/Compat.m
@@ -25,6 +25,33 @@
                           tokenSecret:@"mnop"];
 }
 
++ (NSURLRequest *)makeGetRequestWithValidAdditionalParameters
+{
+    return [TDOAuth URLRequestForPath:@"/service"
+                        GETParameters:@{@"foo": @"bar",
+                                        @"fizz" : @123,
+                                        @"buzz" : @YES}
+                                 host:@"api.example.com"
+                          consumerKey:@"abcd"
+                       consumerSecret:@"efgh"
+                          accessToken:@"ijkl"
+                          tokenSecret:@"mnop"];
+}
+
++ (NSURLRequest *)makeGetRequestWithInvalidAdditionalParameters
+{
+    return [TDOAuth URLRequestForPath:@"/service"
+                        GETParameters:@{@"foo": @"bar",
+                                        @"fizz" : @[@1,@2],
+                                        @"buzz" : @{@"bar": @"foo"}}
+                                 host:@"api.example.com"
+                          consumerKey:@"abcd"
+                       consumerSecret:@"efgh"
+                          accessToken:@"ijkl"
+                          tokenSecret:@"mnop"];
+}
+
+
 + (NSURLRequest *)makeGetComponentsRequest
 {
     NSURLComponents *components = [NSURLComponents new];
@@ -111,7 +138,61 @@
     NSString *contentLength = [getRequest valueForHTTPHeaderField: @"Content-Length"];
     XCTAssertNil(contentLength,
               @"Content-Length was set when not expected)");
+}
 
+-(void)testGetRequestWithValidAdditionalParameters
+{
+    NSURLRequest *getRequest = [self.class makeGetRequestWithValidAdditionalParameters];
+    NSString *url = [[getRequest URL] absoluteString];
+    
+    /// Parameters are not guaranteed to be added to the url in a specific order
+    /// so direct string comparison is not an option. Breaking the url
+    /// down to `NSURLComponents` would allow us to sort and test.
+    NSURLComponents *components = [NSURLComponents componentsWithString:url];
+    
+    NSArray <NSURLQueryItem *> *sortedArray = [components.queryItems sortedArrayUsingComparator:^NSComparisonResult(NSURLQueryItem  * _Nonnull obj1, NSURLQueryItem * _Nonnull obj2) {
+        return [obj1.name compare:obj2.name];
+    }];
+    XCTAssertEqual(sortedArray.count, 3);
+    
+//    NSURLQueryItem *item0 = sortedArray[0];
+//    NSString *string = item0.name;
+//    XCTAssert([item0.name isEqualToString: @"foo"]);
+//    XCTAssertEqual(item0.value, @"bar");
+    
+    
+    XCTAssertEqualObjects(sortedArray[0].name, @"buzz");
+    XCTAssertEqualObjects(sortedArray[0].value, @"1");
+    
+    XCTAssertEqualObjects(sortedArray[1].name, @"fizz");
+    XCTAssertEqualObjects(sortedArray[1].value, @"123");
+    
+    XCTAssertEqualObjects(sortedArray[2].name, @"foo");
+    XCTAssertEqualObjects(sortedArray[2].value, @"bar");
+
+    NSString *contentType = [getRequest valueForHTTPHeaderField: @"Content-Type"];
+    XCTAssertNil(contentType,
+              @"Content-Type was present when not expected)");
+
+    NSString *contentLength = [getRequest valueForHTTPHeaderField: @"Content-Length"];
+    XCTAssertNil(contentLength,
+              @"Content-Length was set when not expected)");
+}
+
+-(void)testGetRequestWithInvalidAdditionalParameters
+{
+    NSURLRequest *getRequest = [self.class makeGetRequestWithInvalidAdditionalParameters];
+    NSString *url = [[getRequest URL] absoluteString];
+    XCTAssert([url isEqualToString:@"http://api.example.com/service?foo=bar"],
+              "url does not match expected value");
+
+    NSString *contentType = [getRequest valueForHTTPHeaderField: @"Content-Type"];
+    XCTAssertNil(contentType,
+              @"Content-Type was present when not expected)");
+
+    NSString *contentLength = [getRequest valueForHTTPHeaderField: @"Content-Length"];
+    XCTAssertNil(contentLength,
+              @"Content-Length was set when not expected)");
 }
 
 #ifdef TEST_NSURLCOMPONENTS

--- a/Example/Tests/Compat.m
+++ b/Example/Tests/Compat.m
@@ -155,12 +155,6 @@
     }];
     XCTAssertEqual(sortedArray.count, 3);
     
-//    NSURLQueryItem *item0 = sortedArray[0];
-//    NSString *string = item0.name;
-//    XCTAssert([item0.name isEqualToString: @"foo"]);
-//    XCTAssertEqual(item0.value, @"bar");
-    
-    
     XCTAssertEqualObjects(sortedArray[0].name, @"buzz");
     XCTAssertEqualObjects(sortedArray[0].value, @"1");
     

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -235,12 +235,22 @@ internal class TDOQueryItem : NSObject {
         var queryItems = [TDOQueryItem]()
 
         if let unencodedParameters = unencodedParameters {
-            for key in unencodedParameters.keys {
-                if let key = key as? String,
-                    let value = unencodedParameters[key] as? String {
-                    let queryItem = TDOQueryItem(name: key, value: value)
-                    queryItems.append(queryItem)
+            for (key, value) in unencodedParameters {
+                guard let key = key as? String else { continue }
+                let formattedValue: String
+                switch value {
+                case let stringValue as String:
+                    formattedValue = stringValue
+                case let intValue as Int:
+                    formattedValue = String(intValue)
+                case let boolValue as Bool:
+                    formattedValue = String(boolValue)
+                default:
+                    /// `value` is not a valid type - skipping
+                    continue
                 }
+                let queryItem = TDOQueryItem(name: key, value: formattedValue)
+                queryItems.append(queryItem)
             }
         }
 

--- a/TDOAuth.podspec
+++ b/TDOAuth.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TDOAuth'
-  s.version          = '1.6.0'
+  s.version          = '1.6.1'
   s.summary          = 'Elegant, simple and compliant OAuth 1.x solution.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
I ran into some bugs after updating from 1.5 to 1.6 and I tracked it down to a change that was made when converting the Objective-C version of the TDOAuth class to Swift.

[Objective C:](https://github.com/yahoo/TDOAuth/blob/429ffbeda9a7460b8764904f0d5fa5a63657835d/Source/compat/TDOAuth.m#L190-L196)
```
 if (unencodedParameters != nil) {
        queryItems = [NSMutableArray new];
        for (NSString *key in unencodedParameters.allKeys) {
            TDOQueryItem *queryItem = [TDOQueryItem itemWithName:key value:unencodedParameters[key]];
            [queryItems addObject:queryItem];
        }
    }
```

[Swift](https://github.com/yahoo/TDOAuth/blob/e328e19959dc252f8921c65fe52273ce0dc171be/Source/compat/TDOAuth.swift#L237-L245):
 ```
 if let unencodedParameters = unencodedParameters {
            for key in unencodedParameters.keys {
                if let key = key as? String,
                    let value = unencodedParameters[key] as? String {
                    let queryItem = TDOQueryItem(name: key, value: value)
                    queryItems.append(queryItem)
                }
            }
        }
```


The `let value = unencodedParameters[key] as? String` in the Swift version causes any value type that isn't a `String` to be ignored and dropped. My particular issue was losing my integer parameters but I added `Bool` handling while I was in there.

I _think_ that should be enough but can add more if needed.