### PR TITLE
TDOAuth.swift refinement

### DIFF
--- a/Example/TDOAuth.xcodeproj/project.pbxproj
+++ b/Example/TDOAuth.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		607FACEC1AFB9204008FA782 /* OAuth1Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* OAuth1Spec.swift */; };
 		9810E2CF42C71CB54FC9817B /* Pods_TDOAuth_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9AE6DB313043BFD421E116D /* Pods_TDOAuth_watchOS.framework */; };
 		ED3586181D3AC6A5F479F62A /* Pods_TDOAuth_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1468F75DCB0D1331A62E245C /* Pods_TDOAuth_iOS.framework */; };
+		F2E921622907D5640093DBB4 /* TestTDOQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E921612907D5640093DBB4 /* TestTDOQueryItem.swift */; };
 		FC71E7F42416E7A200CCC34C /* Compat.m in Sources */ = {isa = PBXBuildFile; fileRef = FC71E7F32416E7A200CCC34C /* Compat.m */; };
 		FCC067C9241C1940004997C8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC067C8241C1940004997C8 /* AppDelegate.swift */; };
 		FCC067CB241C1940004997C8 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC067CA241C1940004997C8 /* ViewController.swift */; };
@@ -134,6 +135,7 @@
 		E5897B5C42516E19A5C8C497 /* Pods_TDOAuth_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TDOAuth_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6AC1FB932F461059AB20B60 /* Pods-TDOAuth_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TDOAuth_Example.release.xcconfig"; path = "Target Support Files/Pods-TDOAuth_Example/Pods-TDOAuth_Example.release.xcconfig"; sourceTree = "<group>"; };
 		ECC894BE67C3786829385505 /* Pods-TDOAuth-TDOAuth-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TDOAuth-TDOAuth-iOS.release.xcconfig"; path = "Target Support Files/Pods-TDOAuth-TDOAuth-iOS/Pods-TDOAuth-TDOAuth-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		F2E921612907D5640093DBB4 /* TestTDOQueryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTDOQueryItem.swift; sourceTree = "<group>"; };
 		F2EA75221BBDF7E5162DF034 /* Pods-TDOAuth_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TDOAuth_iOS.release.xcconfig"; path = "Target Support Files/Pods-TDOAuth_iOS/Pods-TDOAuth_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		FC71E7F22416E7A100CCC34C /* TDOAuth_Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TDOAuth_Tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		FC71E7F32416E7A200CCC34C /* Compat.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Compat.m; sourceTree = "<group>"; };
@@ -310,6 +312,7 @@
 				FCCE3C4421FAE14200522CBD /* HMACSpec.swift */,
 				FCCE3C4621FAE1E000522CBD /* PlaintextSpec.swift */,
 				FCCE3C4821FAE23F00522CBD /* Utils.swift */,
+				F2E921612907D5640093DBB4 /* TestTDOQueryItem.swift */,
 				FC71E7F32416E7A200CCC34C /* Compat.m */,
 				FC71E7F22416E7A100CCC34C /* TDOAuth_Tests-Bridging-Header.h */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
@@ -820,6 +823,7 @@
 				607FACEC1AFB9204008FA782 /* OAuth1Spec.swift in Sources */,
 				FCCE3C4921FAE23F00522CBD /* Utils.swift in Sources */,
 				FC71E7F42416E7A200CCC34C /* Compat.m in Sources */,
+				F2E921622907D5640093DBB4 /* TestTDOQueryItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Tests/TestTDOQueryItem.swift
+++ b/Example/Tests/TestTDOQueryItem.swift
@@ -65,7 +65,7 @@ class TestTDOQueryItem: XCTestCase {
         }
 
         if let dictionaryItem = queryItems.first(where: { $0.name == "key_dictionary" }) {
-            XCTAssert(dictionaryItem.stringValue == "{\n    \"dic_number\" = 761;\n    \"dic_string\" = dictionary;\n}")
+            XCTAssert(dictionaryItem.stringValue == "[\"dic_string\": \"dictionary\", \"dic_number\": 761]")
             XCTAssert((dictionaryItem.rawValue as? Dictionary<String, Any>)?["dic_string"] as? String == "dictionary")
             XCTAssert((dictionaryItem.rawValue as? Dictionary<String, Any>)?["dic_number"] as? Int == 761)
         } else {
@@ -73,7 +73,7 @@ class TestTDOQueryItem: XCTestCase {
         }
 
         if let arrayItem = queryItems.first(where: { $0.name == "key_array" }) {
-            XCTAssert(arrayItem.stringValue == "(\n    array1,\n    array2,\n    array3\n)")
+            XCTAssert(arrayItem.stringValue == "[\"array1\", \"array2\", \"array3\"]")
             XCTAssert((arrayItem.rawValue as? Array)?[0] == "array1")
             XCTAssert((arrayItem.rawValue as? Array)?[1] == "array2")
             XCTAssert((arrayItem.rawValue as? Array)?[2] == "array3")

--- a/Example/Tests/TestTDOQueryItem.swift
+++ b/Example/Tests/TestTDOQueryItem.swift
@@ -65,7 +65,7 @@ class TestTDOQueryItem: XCTestCase {
         }
 
         if let dictionaryItem = queryItems.first(where: { $0.name == "key_dictionary" }) {
-            XCTAssert(dictionaryItem.stringValue == "[\"dic_string\": \"dictionary\", \"dic_number\": 761]")
+            XCTAssert(dictionaryItem.stringValue == "[\"dic_string\": \"dictionary\", \"dic_number\": 761]" || dictionaryItem.stringValue == "[\"dic_number\": 761, \"dic_string\": \"dictionary\"]")
             XCTAssert((dictionaryItem.rawValue as? Dictionary<String, Any>)?["dic_string"] as? String == "dictionary")
             XCTAssert((dictionaryItem.rawValue as? Dictionary<String, Any>)?["dic_number"] as? Int == 761)
         } else {

--- a/Example/Tests/TestTDOQueryItem.swift
+++ b/Example/Tests/TestTDOQueryItem.swift
@@ -1,0 +1,92 @@
+// Copyright 2022, Yahoo Inc.
+// Licensed under the terms of the MIT license. See LICENSE file in https://github.com/yahoo/TDOAuth for terms.
+
+import XCTest
+@testable import TDOAuth
+
+class TestTDOQueryItem: XCTestCase {
+
+    static var paramDictionary: [AnyHashable: Any] {
+        return [
+            "key_string": "value_string",
+            "key_positive_int": Int(808),
+            "key_negative_int": Int(-394),
+            "key_double": Double(3.141592653589793),
+            "key_float": Float(3.1415925),
+            "key_dictionary": [
+                "dic_string": "dictionary",
+                "dic_number": Int(761)
+            ],
+            "key_array": ["array1", "array2", "array3"],
+            "key_bool": true
+        ]
+    }
+
+    func testStringParam() {
+        guard let queryItems = TDOQueryItem.getItems(from: Self.paramDictionary) else {
+            assertionFailure("TDOQueryItem: parse parameters failed.")
+            return
+        }
+        XCTAssert(queryItems.count == 8)
+
+        if let stringItem = queryItems.first(where: { $0.name == "key_string" }) {
+            XCTAssert(stringItem.stringValue == "value_string")
+            XCTAssert(stringItem.rawValue as? String == "value_string")
+        } else {
+            assertionFailure("TDOQueryItem: parse string item failed.")
+        }
+
+        if let positiveIntItem = queryItems.first(where: { $0.name == "key_positive_int" }) {
+            XCTAssert(positiveIntItem.stringValue == "808")
+            XCTAssert(positiveIntItem.rawValue as? Int == Int(808))
+        } else {
+            assertionFailure("TDOQueryItem: parse positive int item failed.")
+        }
+
+        if let negativeIntItem = queryItems.first(where: { $0.name == "key_negative_int" }) {
+            XCTAssert(negativeIntItem.stringValue == "-394")
+            XCTAssert(negativeIntItem.rawValue as? Int == Int(-394))
+        } else {
+            assertionFailure("TDOQueryItem: parse negative int item failed.")
+        }
+
+        if let doubleItem = queryItems.first(where: { $0.name == "key_double" }) {
+            XCTAssert(doubleItem.stringValue == NSNumber(value: Double(3.141592653589793)).stringValue)
+            XCTAssert(doubleItem.rawValue as? Double == Double(3.141592653589793))
+        } else {
+            assertionFailure("TDOQueryItem: parse double item failed.")
+        }
+
+        if let floatItem = queryItems.first(where: { $0.name == "key_float" }) {
+            XCTAssert(floatItem.stringValue == NSNumber(value: Float(3.1415925)).stringValue)
+            XCTAssert(floatItem.rawValue as? Float == Float(3.1415925))
+        } else {
+            assertionFailure("TDOQueryItem: parse float item failed.")
+        }
+
+        if let dictionaryItem = queryItems.first(where: { $0.name == "key_dictionary" }) {
+            XCTAssert(dictionaryItem.stringValue == "{\n    \"dic_number\" = 761;\n    \"dic_string\" = dictionary;\n}")
+            XCTAssert((dictionaryItem.rawValue as? Dictionary<String, Any>)?["dic_string"] as? String == "dictionary")
+            XCTAssert((dictionaryItem.rawValue as? Dictionary<String, Any>)?["dic_number"] as? Int == 761)
+        } else {
+            assertionFailure("TDOQueryItem: parse dictionary item failed.")
+        }
+
+        if let arrayItem = queryItems.first(where: { $0.name == "key_array" }) {
+            XCTAssert(arrayItem.stringValue == "(\n    array1,\n    array2,\n    array3\n)")
+            XCTAssert((arrayItem.rawValue as? Array)?[0] == "array1")
+            XCTAssert((arrayItem.rawValue as? Array)?[1] == "array2")
+            XCTAssert((arrayItem.rawValue as? Array)?[2] == "array3")
+        } else {
+            assertionFailure("TDOQueryItem: parse array item failed.")
+        }
+
+        if let boolItem = queryItems.first(where: { $0.name == "key_bool" }) {
+            XCTAssert(boolItem.stringValue == "1")
+            XCTAssert(boolItem.rawValue as? Bool == true)
+        } else {
+            assertionFailure("TDOQueryItem: parse bool item failed.")
+        }
+    }
+
+}

--- a/Example/Tests/TestTDOQueryItem.swift
+++ b/Example/Tests/TestTDOQueryItem.swift
@@ -23,7 +23,7 @@ class TestTDOQueryItem: XCTestCase {
     }
 
     func testStringParam() {
-        guard let queryItems = TDOQueryItem.getItems(from: Self.paramDictionary) else {
+        guard let queryItems = TDOQueryItem.getItems(from: Self.paramDictionary, isCollectionValuesSupported: true) else {
             assertionFailure("TDOQueryItem: parse parameters failed.")
             return
         }

--- a/Example/Tests/TestTDOQueryItem.swift
+++ b/Example/Tests/TestTDOQueryItem.swift
@@ -51,14 +51,14 @@ class TestTDOQueryItem: XCTestCase {
         }
 
         if let doubleItem = queryItems.first(where: { $0.name == "key_double" }) {
-            XCTAssert(doubleItem.stringValue == NSNumber(value: Double(3.141592653589793)).stringValue)
+            XCTAssert(doubleItem.stringValue == "3.141592653589793")
             XCTAssert(doubleItem.rawValue as? Double == Double(3.141592653589793))
         } else {
             assertionFailure("TDOQueryItem: parse double item failed.")
         }
 
         if let floatItem = queryItems.first(where: { $0.name == "key_float" }) {
-            XCTAssert(floatItem.stringValue == NSNumber(value: Float(3.1415925)).stringValue)
+            XCTAssert(floatItem.stringValue == "3.1415925")
             XCTAssert(floatItem.rawValue as? Float == Float(3.1415925))
         } else {
             assertionFailure("TDOQueryItem: parse float item failed.")
@@ -82,7 +82,7 @@ class TestTDOQueryItem: XCTestCase {
         }
 
         if let boolItem = queryItems.first(where: { $0.name == "key_bool" }) {
-            XCTAssert(boolItem.stringValue == "1")
+            XCTAssert(boolItem.stringValue == "true")
             XCTAssert(boolItem.rawValue as? Bool == true)
         } else {
             assertionFailure("TDOQueryItem: parse bool item failed.")

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -361,9 +361,9 @@ internal class TDOQueryItem : NSObject {
             else if (dataEncoding == .jsonObject)
             {
                 // This falls back to dictionary as not sure what's the proper action here.
-                var unencodedParameters = [String:String]()
+                var unencodedParameters = [String: Any]()
                 for queryItem in queryItems {
-                    unencodedParameters[queryItem.name] = queryItem.value;
+                    unencodedParameters[queryItem.name] = queryItem.rawValue ?? queryItem.stringValue
                 }
                 do {
                     let postbody = try JSONSerialization.data(withJSONObject: unencodedParameters)

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -101,7 +101,7 @@ internal class TDOQueryItem : NSObject {
                              headerValues:nil,
                           signatureMethod:.hmacSha1)
     }
-    
+
     /**
       Some services insist on HTTPS. Or maybe you don't want the data to be sniffed.
       You can pass @"https" via the scheme parameter.
@@ -193,11 +193,11 @@ internal class TDOQueryItem : NSObject {
                           headerValues:nil,
                        signatureMethod:.hmacSha1)
     }
-        
+
     /**
      This method allows the caller to specify particular values for many different parameters such
      as scheme, method, header values and alternate signature hash algorithms.
-    
+
      @p scheme may be any string value, generally "http" or "https".
      @p requestMethod may be any string value. There is no validation, so remember that all
      currently-defined HTTP methods are uppercase and the RFC specifies that the method
@@ -233,7 +233,7 @@ internal class TDOQueryItem : NSObject {
                                dataEncoding: TDOAuthContentType,
                                headerValues: [AnyHashable : Any]?,
                                signatureMethod: TDOAuthSignatureMethod) -> URLRequest! {
-        
+
         var queryItems = [TDOQueryItem]()
 
         if let unencodedParameters = unencodedParameters {
@@ -253,6 +253,7 @@ internal class TDOQueryItem : NSObject {
                     formattedValue = String(describing: dictionaryValue)
                 default:
                     /// `value` is not a valid type - skipping
+                    assertionFailure("TDOAuth: failed to casting the parameter: \(value) for the key: \(key)")
                     continue
                 }
                 let queryItem = TDOQueryItem(name: key, rawValue: value, stringValue: formattedValue)
@@ -319,7 +320,7 @@ internal class TDOQueryItem : NSObject {
         guard let host = host, let unencodedPathWithoutQuery = unencodedPathWithoutQuery, let scheme = scheme, let method = method else {
             return nil
         }
-        
+
         // We don't use pcen as we don't want to percent encode eg. /, this is perhaps
         // not the most all encompassing solution, but in practice it seems to work
         // everywhere and means that programmer error is *much* less likely.
@@ -385,11 +386,11 @@ internal class TDOQueryItem : NSObject {
             }
             else // invalid type
             {
-                return nil;
+                return nil
             }
         }
 
-        return rq;
+        return rq
     }
 
     // METHOD ADAPTED FROM LEGACY OAUTH1 CLIENT
@@ -411,7 +412,7 @@ internal class TDOQueryItem : NSObject {
                 queryString.append(envalue)
             }
         }
-        return queryString;
+        return queryString
     }
 
     // METHOD ADAPTED FROM LEGACY OAUTH1 CLIENT
@@ -439,7 +440,7 @@ internal class TDOQueryItem : NSObject {
     }
 
     /**
-    
+
      OAuth requires the UTC timestamp we send to be accurate. The user's device
      may not be, and often isn't. To work around this you should set this to the
      UTC timestamp that you get back in HTTP headers from OAuth servers.

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -243,10 +243,14 @@ internal class TDOQueryItem : NSObject {
                 switch value {
                 case let stringValue as String:
                     formattedValue = stringValue
-                case let intValue as Int:
-                    formattedValue = String(intValue)
+                case let numberValue as NSNumber:
+                    formattedValue = numberValue.stringValue
                 case let boolValue as Bool:
                     formattedValue = String(boolValue)
+                case let arrayValue as NSArray:
+                    formattedValue = String(describing: arrayValue)
+                case let dictionaryValue as NSDictionary:
+                    formattedValue = String(describing: dictionaryValue)
                 default:
                     /// `value` is not a valid type - skipping
                     continue

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -52,12 +52,14 @@ let TDOAuthURLRequestTimeout = 30.0
 // MARK: -
 
 internal class TDOQueryItem : NSObject {
-    var name : String
-    var value: String
-    
-    init(name: String, value: String) {
+    var name: String
+    var rawValue: Any?
+    var stringValue: String
+
+    init(name: String, rawValue: Any? = nil, stringValue: String) {
         self.name = name
-        self.value = value
+        self.rawValue = rawValue
+        self.stringValue = stringValue
     }
 }
 
@@ -171,8 +173,8 @@ internal class TDOQueryItem : NSObject {
         var queryItems = [TDOQueryItem]()
         if let items = urlComponents.queryItems {
             items.forEach { item in
-                if let value = item.value {
-                    let queryItem = TDOQueryItem(name: item.name, value: value)
+                if let stringValue = item.value {
+                    let queryItem = TDOQueryItem(name: item.name, stringValue: stringValue)
                     queryItems.append(queryItem)
                 }
             }
@@ -249,7 +251,7 @@ internal class TDOQueryItem : NSObject {
                     /// `value` is not a valid type - skipping
                     continue
                 }
-                let queryItem = TDOQueryItem(name: key, value: formattedValue)
+                let queryItem = TDOQueryItem(name: key, rawValue: value, stringValue: formattedValue)
                 queryItems.append(queryItem)
             }
         }
@@ -394,12 +396,12 @@ internal class TDOQueryItem : NSObject {
         var encodedParameters = [TDOQueryItem]()
         for queryItem in unencodedParameters {
             let enkey = TDPCEN(queryItem.name)
-            let envalue = TDPCEN(queryItem.value)
+            let envalue = TDPCEN(queryItem.stringValue)
             if let enkey = enkey, let envalue = envalue {
                 if queryString.count > 0 {
                     queryString.append("&")
                 }
-                encodedParameters.append(TDOQueryItem(name: enkey, value: envalue))
+                encodedParameters.append(TDOQueryItem(name: enkey, stringValue: envalue))
                 queryString.append(enkey)
                 queryString.append("=")
                 queryString.append(envalue)

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -65,6 +65,8 @@ internal class TDOQueryItem : NSObject {
     private class func getStringValue(by rawValue: Any) -> String? {
         var formattedValue: String?
         switch rawValue {
+        case let losslessString as LosslessStringConvertible:
+            formattedValue = losslessString.description
         case let stringValue as String:
             formattedValue = stringValue
         case let numberValue as NSNumber:

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -65,17 +65,15 @@ internal class TDOQueryItem : NSObject {
     private class func getStringValue(by rawValue: Any) -> String? {
         var formattedValue: String?
         switch rawValue {
-        case let losslessString as LosslessStringConvertible:
+        case let losslessString as CustomStringConvertible:
             formattedValue = losslessString.description
-        case let stringValue as String:
-            formattedValue = stringValue
-        case let numberValue as NSNumber:
-            formattedValue = numberValue.stringValue
-        case let boolValue as Bool:
-            formattedValue = String(boolValue)
-        case let arrayValue as NSArray:
+        case let nsObject as NSObjectProtocol:
+            formattedValue = nsObject.description
+        case let arrayValue as Array<CustomStringConvertible>:
             formattedValue = String(describing: arrayValue)
-        case let dictionaryValue as NSDictionary:
+        case let arrayValue as Array<NSObjectProtocol>:
+            formattedValue = String(describing: arrayValue)
+        case let dictionaryValue as Dictionary<AnyHashable, Any>:
             formattedValue = String(describing: dictionaryValue)
         default:
             /// `value` is not a valid type - skipping

--- a/TDOAuth.podspec
+++ b/TDOAuth.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TDOAuth'
-  s.version          = '1.6.1'
+  s.version          = '1.6.2'
   s.summary          = 'Elegant, simple and compliant OAuth 1.x solution.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This PR is to fix:
- Some parameters are dropped because insufficient type casting on `TDOQueryItem`.
- Encoding JSON object's `httpBody` failure
- Add tests for `TDOQueryItem` to make sure the type casting is correct.