### PR TITLE
Fix dropping collection values in GET calls

### DIFF
--- a/Example/Tests/Compat.m
+++ b/Example/Tests/Compat.m
@@ -177,8 +177,10 @@
 {
     NSURLRequest *getRequest = [self.class makeGetRequestWithInvalidAdditionalParameters];
     NSString *url = [[getRequest URL] absoluteString];
-    XCTAssert([url isEqualToString:@"http://api.example.com/service?foo=bar"],
-              "url does not match expected value");
+    XCTAssert([url containsString: @"http://api.example.com/service?"], @"url does not match expected value");
+    XCTAssert([url containsString: @"foo=bar"], @"url does not match expected value");
+    XCTAssert([url containsString: @"fizz=%28%0A%20%20%20%201%2C%0A%20%20%20%202%0A%29"], @"url does not match expected value");
+    XCTAssert([url containsString: @"buzz=%7B%0A%20%20%20%20bar%20%3D%20foo%3B%0A%7D"], @"url does not match expected value");
 
     NSString *contentType = [getRequest valueForHTTPHeaderField: @"Content-Type"];
     XCTAssertNil(contentType,

--- a/Example/Tests/TestTDOQueryItem.swift
+++ b/Example/Tests/TestTDOQueryItem.swift
@@ -23,7 +23,7 @@ class TestTDOQueryItem: XCTestCase {
     }
 
     func testStringParam() {
-        guard let queryItems = TDOQueryItem.getItems(from: Self.paramDictionary, isCollectionValuesSupported: true) else {
+        guard let queryItems = TDOQueryItem.getItems(from: Self.paramDictionary) else {
             assertionFailure("TDOQueryItem: parse parameters failed.")
             return
         }

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -62,11 +62,7 @@ internal class TDOQueryItem : NSObject {
         self.stringValue = Self.getStringValue(by: rawValue)
     }
 
-    private class func getStringValue(by rawValue: Any, isCollectionValuesSupported: Bool = true) -> String? {
-        if !isCollectionValuesSupported,
-            (rawValue is Array<Any> || rawValue is Dictionary<AnyHashable, Any>) {
-            return nil
-        }
+    private class func getStringValue(by rawValue: Any) -> String? {
         var formattedValue: String?
         switch rawValue {
         case let losslessString as CustomStringConvertible:
@@ -86,17 +82,15 @@ internal class TDOQueryItem : NSObject {
         return formattedValue
     }
 
-    class func getItems(from dictionary: [AnyHashable: Any]?, isCollectionValuesSupported: Bool = true) -> [TDOQueryItem]? {
+    class func getItems(from dictionary: [AnyHashable: Any]?) -> [TDOQueryItem]? {
         guard let dic = dictionary else { return nil }
         var queryItems = [TDOQueryItem]()
 
         for (key, value) in dic {
             guard let key = key as? String else { continue }
-            if Self.getStringValue(by: value, isCollectionValuesSupported: isCollectionValuesSupported) == nil {
-                if isCollectionValuesSupported {
-                    /// `value` is not a valid type - skipping
-                    assertionFailure("TDOAuth: failed to casting the parameter: \(value) for the key: \(key)")
-                }
+            if Self.getStringValue(by: value) == nil {
+                /// `value` is not a valid type - skipping
+                assertionFailure("TDOAuth: failed to casting the parameter: \(value) for the key: \(key)")
                 continue
             }
             let queryItem = TDOQueryItem(name: key, rawValue: value)
@@ -279,7 +273,7 @@ internal class TDOQueryItem : NSObject {
                                signatureMethod: TDOAuthSignatureMethod) -> URLRequest! {
 
         return self.urlRequest(forPath: unencodedPathWithoutQuery,
-                               queryItems: TDOQueryItem.getItems(from: unencodedParameters, isCollectionValuesSupported: method == "POST") ?? [],
+                               queryItems: TDOQueryItem.getItems(from: unencodedParameters) ?? [],
                                host: host,
                                consumerKey: consumerKey,
                                consumerSecret: consumerSecret,

--- a/TDOAuth.podspec
+++ b/TDOAuth.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TDOAuth'
-  s.version          = '1.6.2'
+  s.version          = '1.6.3'
   s.summary          = 'Elegant, simple and compliant OAuth 1.x solution.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The test `testGetRequestWithInvalidAdditionalParameters` was added in `TDOAuth 1.6.1` which has problem in parsing parameters (PR: https://github.com/yahoo/TDOAuth/pull/43). It passed successfully because the `TDOAuth.swift` drops `Array` and `Dictionary` types of values by accident. 
This PR is to make the test result equal to what `TDOAuth 1.5.0` (`TDOAuth.m`) processes.