### PR TITLE
Fix SPM dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ let package = Package(
         .target(
             name: "TDOAuth",
             dependencies: [
-                .product(name: "OMGHTTPURLRQ", package: "OMGHTTPURLRQ"),
                 .product(name: "OMGHTTPURLRQUserAgent", package: "OMGHTTPURLRQ")
             ],
             path: "Source"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
         .target(
             name: "TDOAuth",
             dependencies: [
-                "OMGHTTPURLRQ"
+                .product(name: "OMGHTTPURLRQ", package: "OMGHTTPURLRQ"),
+                .product(name: "OMGHTTPURLRQUserAgent", package: "OMGHTTPURLRQ")
             ],
             path: "Source"),
     ]

--- a/Source/compat/TDOAuth.swift
+++ b/Source/compat/TDOAuth.swift
@@ -28,7 +28,11 @@
 */
 
 import Foundation
-import OMGHTTPURLRQ
+#if canImport(OMGHTTPURLRQUserAgent)
+import OMGHTTPURLRQUserAgent /// SPM
+#else
+import OMGHTTPURLRQ /// Cococapods
+#endif
 
 // MARK: From TDOAuth.h
 


### PR DESCRIPTION
For some reason the OMGHTTPURLRQUserAgent dependency must explicitly called out or "Test" will not build/link due to missing symbol.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
